### PR TITLE
Add instructions on how to build HTML from RST using sphinx-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Thumbs.db
 ###############
 _build
 build
+
+# Python Virtual Environment
+.venv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Python Flask API Lab
+
+Content used for lab generation on HoW.
+
+## Building the Site
+
+```
+# Set up a Python 3 virtual environment to install dependencies to...
+> python3 -m venv .venv
+
+# Activate the venv
+> source .venv/bin/activate
+
+# Install dependencies from requirements.txt...
+> pip install -r requirements.txt
+
+# Use sphinx to build the site...
+> sphinx-build . _build
+```

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,0 @@
-Python Flask API Lab
-####################
-
-Content used for lab generation on HoW.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sphinxcontrib-fulltoc == 1.2.0
+sphinx-bootstrap-theme == 0.6.0
+sphinx_fontawesome
+sphinx


### PR DESCRIPTION
Hello!

💁‍♀️  This PR adds instructions on how to produce an HTML website based on the RST documents in the repository!

Currently, our `conf.py` is configured to use (what I think is) the base Sphinx theme. This produces a result somewhat similar to:

![image](https://user-images.githubusercontent.com/2453394/165631747-bd3866c2-33f9-4560-8624-7ac69e956b6b.png)

In `README.md`, we add instructions on how to use Python 3 to create a virtual environment where our dependencies are stored, install those dependencies (from `requirements.txt`) and then finally, produce the HTML site using `sphinx-build`.

Let me know if there are any questions around additional theming or automation and I'm glad to help!